### PR TITLE
Add support for stable Rust 1.75.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //! [`bluenrg`]: https://github.com/danielgallagher0/bluenrg
 
 #![no_std]
-#![feature(async_fn_in_trait)]
+#![allow(async_fn_in_trait)]
 
 extern crate byteorder;
 


### PR DESCRIPTION
- Remove `feature(async_fn_in_trait)`, it's stable now
- Add `feature(async_fn_in_trait)`, to silence the lint that doesn't apply to embedded.