### PR TITLE
[~] Fix to_l2cap_connection_update_response and GattNotificationComplete parsing

### DIFF
--- a/src/vendor/event/mod.rs
+++ b/src/vendor/event/mod.rs
@@ -824,8 +824,8 @@ impl VendorEvent {
                 to_gatt_multi_notification(buffer)?,
             )),
             0x0C1B => Ok(VendorEvent::GattNotificationComplete({
-                require_len!(buffer, 2);
-                AttributeHandle(LittleEndian::read_u16(buffer))
+                require_len!(buffer[2..], 2);
+                AttributeHandle(LittleEndian::read_u16(&buffer[2..]))
             })),
             0x0C1D => Ok(VendorEvent::GattReadExt(to_gatt_read_ext(buffer)?)),
             0x0C1E => Ok(VendorEvent::GattIndicationExt(to_attribute_value_ext(
@@ -981,13 +981,12 @@ fn extract_l2cap_connection_update_response_result(
 fn to_l2cap_connection_update_response(
     buffer: &[u8],
 ) -> Result<L2CapConnectionUpdateResponse, crate::event::Error> {
-    require_len!(buffer, 11);
-    require_l2cap_event_data_len!(buffer, 6);
-    require_l2cap_len!(LittleEndian::read_u16(&buffer[7..]), 2);
+    require_len!(buffer, 6);
+    require_l2cap_event_data_len!(buffer, 0);
 
     Ok(L2CapConnectionUpdateResponse {
         conn_handle: ConnectionHandle(LittleEndian::read_u16(&buffer[2..])),
-        result: extract_l2cap_connection_update_response_result(buffer)
+        result: to_l2cap_connection_update_accepted_result(LittleEndian::read_u16(&buffer[4..]))
             .map_err(crate::event::Error::Vendor)?,
     })
 }


### PR DESCRIPTION
Hello,

I saw `BLE(BadLength(6, 11))` after a connection parameter update request.
So, i analysed raw HCI frameand figured out that ACI_L2CAP_CONNECTION_UPDATE_RESP_EVENT has only 4 bytes of data:
<img width="935" height="242" alt="image" src="https://github.com/user-attachments/assets/aa99e275-14c9-4b81-81ef-f46b4af2dc1a" />

I also found issue with GattNotificationComplete parsing.
 
Maybe into `impl VendorEvent` it's possible to separate input buffer into 2 variables, `let event_code = LittleEndian::read_u16(&buffer[0..=1]);` and a new one like `let payload` ?

I my application i want to send notification events asynchronously. My solution is to use a select on two futures like this:

```rust
  let response_result = select(
      ble_read_cb(&mut ble, &mut ble_context),
      BLE_TX_CHANNEL.receive(),
  )
  .await;
```

but i think that BLE controller doesn't like it when BLE_TX_CHANNEL.receive() arrives at the wrong time. I have this kind of errors `BadPacketType(1)` and my code is stucked
