### PR TITLE
split read and write traits

### DIFF
--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -8,8 +8,8 @@
 //!   support sending the packet ID, as `uart` does. In that case, it would make sense to also remove
 //!   `uart` and move its contents up one level.
 
-use crate::ConnectionHandle;
 use crate::event::{NUMBER_OF_COMPLETED_PACKETS_MAX_LEN, NumberOfCompletedPackets};
+use crate::{ConnectionHandle, WritableController};
 use byteorder::{ByteOrder, LittleEndian};
 use core::convert::Into;
 use core::fmt::{Debug, Formatter, Result as FmtResult};
@@ -57,7 +57,7 @@ pub trait HciHeader {
 /// Specializations must define the error type `E`, used for communication errors.
 ///
 /// An implementation is defined or all types that implement [`Controller`](super::Controller).
-pub trait HostHci {
+pub trait HostHci: WritableController {
     /// Terminates an existing connection.  All synchronous connections on a physical link should be
     /// disconnected before the ACL connection on the same physical connection is disconnected.
     ///
@@ -1156,7 +1156,7 @@ async fn set_outbound_data<T>(
     data: &[u8],
 ) -> Result<(), Error>
 where
-    T: crate::Controller,
+    T: crate::WritableController,
 {
     const MAX_DATA_LEN: usize = 31;
     if data.len() > MAX_DATA_LEN {
@@ -1172,7 +1172,7 @@ where
 
 impl<T> HostHci for T
 where
-    T: crate::Controller,
+    T: crate::WritableController,
 {
     async fn disconnect(
         &mut self,

--- a/src/host/uart.rs
+++ b/src/host/uart.rs
@@ -2,6 +2,8 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 
+use crate::ReadableController;
+
 const PACKET_TYPE_HCI_COMMAND: u8 = 0x01;
 // const PACKET_TYPE_ACL_DATA: u8 = 0x02;
 // const PACKET_TYPE_SYNC_DATA: u8 = 0x03;
@@ -39,13 +41,9 @@ pub struct CommandHeader {
 
 /// Trait for reading packets from the controller.
 ///
-/// Implementors must also implement [`crate::host::HostHci`], which provides all of the functions to
-/// write commands to the controller. This trait adds the ability to read packets back from the
-/// controller.
-///
 /// Must be specialized for communication errors (`E`), vendor-specific events (`Vendor`), and
 /// vendor-specific errors (`VE`).
-pub trait UartHci: super::HostHci {
+pub trait UartHci: ReadableController {
     /// Reads and returns a packet from the controller. Consumes exactly enough bytes to read the
     /// next packet including its header.
     ///
@@ -80,7 +78,7 @@ impl super::HciHeader for CommandHeader {
 
 impl<T> UartHci for T
 where
-    T: crate::Controller,
+    T: crate::ReadableController,
 {
     async fn read(&mut self) -> Result<Packet, Error> {
         const MAX_EVENT_LENGTH: usize = 256;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,28 @@ pub trait Controller {
     async fn controller_read_into(&mut self, buf: &mut [u8]);
 }
 
+pub trait ReadableController {
+    /// Reads data from the controller into the provided `buffer`. See `Controller::controller_read_into.`
+    async fn controller_read_into(&mut self, buf: &mut [u8]);
+}
+
+impl<T: Controller> ReadableController for T {
+    async fn controller_read_into(&mut self, buf: &mut [u8]) {
+        <T as Controller>::controller_read_into(self, buf).await
+    }
+}
+
+pub trait WritableController {
+    /// Writes data to the controller into the provided `buffer`. See `Controller::contoller_write.`
+    async fn controller_write(&mut self, opcode: Opcode, payload: &[u8]);
+}
+
+impl<T: Controller> WritableController for T {
+    async fn controller_write(&mut self, opcode: Opcode, payload: &[u8]) {
+        <T as Controller>::controller_write(self, opcode, payload).await
+    }
+}
+
 /// List of possible error codes, Bluetooth Spec, Vol 2, Part D, Section 2.
 ///
 /// Includes an extension point for vendor-specific status codes.


### PR DESCRIPTION
This allows manually implementing event parsing, which avoids a copy, and allows compile-time checking for split read and write methods.