### PR TITLE
chore: update to bt hci 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,10 +79,11 @@ dependencies = [
 
 [[package]]
 name = "bt-hci"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3c66fd0a41a3b3a5906847b1bf5516048ce083e24fa9341a0fa31d3b4cd73d"
+checksum = "a9670c1c3285fdaa99ade6edf5a3ed47bc14227f49b5e48cc587ef190485eaeb"
 dependencies = [
+ "bt-hci-transport",
  "btuuid",
  "defmt 1.1.0",
  "embassy-sync",
@@ -90,6 +91,17 @@ dependencies = [
  "embedded-io-async",
  "futures-intrusive",
  "heapless",
+]
+
+[[package]]
+name = "bt-hci-transport"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffb9819c69cf88877f5eebc8c5ade0ab50f2bf9475bbb3eb714d66c55b0cb64"
+dependencies = [
+ "defmt 1.1.0",
+ "embedded-io",
+ "embedded-io-async",
 ]
 
 [[package]]
@@ -971,6 +983,7 @@ version = "0.18.0"
 dependencies = [
  "bitflags 2.11.1",
  "bt-hci",
+ "bt-hci-transport",
  "byteorder",
  "critical-section",
  "defmt 1.1.0",
@@ -985,6 +998,7 @@ version = "0.1.0"
 dependencies = [
  "aligned",
  "bt-hci",
+ "bt-hci-transport",
  "cortex-m",
  "cortex-m-rt",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ exclude = ["tests"]
 
 [dependencies]
 bitflags = "2"
-bt-hci = "0.9.0"
+bt-hci = "0.10.0"
+bt-hci-transport = "0.1.0"
 byteorder = { version = "1", default-features = false }
 defmt = { version = "1", optional = true }
 embedded-io = "0.7.1"
@@ -36,7 +37,7 @@ critical-section = { version = "1.2", features = ["std"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
-defmt = ["dep:defmt", "bt-hci/defmt"]
+defmt = ["dep:defmt", "bt-hci/defmt", "bt-hci-transport/defmt"]
 
 [profile.dev]
 debug = 2

--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -22,6 +22,7 @@ embassy-stm32 = { version = "0.6.0", features = [
 embassy-sync = { version = "0.8.0", features = ["defmt"] }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 stm32wb-hci = { path = "../../", features = ["defmt"] }
-bt-hci = "0.9.0"
+bt-hci = "0.10.0"
+bt-hci-transport = "0.1.0"
 embedded-io = "0.7.1"
 embassy-futures = "0.1.2"

--- a/examples/embassy/src/transport.rs
+++ b/examples/embassy/src/transport.rs
@@ -1,5 +1,6 @@
 use aligned::{A4, Aligned};
-use bt_hci::{WriteHci, transport::WithIndicator};
+use bt_hci::transport::WithIndicator;
+use bt_hci_transport::PacketToController;
 use core::{
     cell::RefCell,
     future::poll_fn,
@@ -350,7 +351,7 @@ impl<'d> ControllerAdapter<'d> {
         ))
     }
 
-    async fn exec_cmd<C: bt_hci::WriteHci + bt_hci::cmd::Cmd>(
+    async fn exec_cmd<C: PacketToController + bt_hci::cmd::Cmd>(
         &self,
         cmd: &C,
     ) -> Result<
@@ -394,6 +395,12 @@ impl<'d> ControllerAdapter<'d> {
 }
 
 impl<'d> bt_hci::controller::Controller for ControllerAdapter<'d> {
+    type Buffer<'a> = ();
+
+    fn alloc_buf(&self) -> Result<Self::Buffer<'_>, Self::Error> {
+        Ok(())
+    }
+
     async fn write_acl_data(
         &self,
         _packet: &bt_hci::data::AclPacket<'_>,
@@ -417,7 +424,7 @@ impl<'d> bt_hci::controller::Controller for ControllerAdapter<'d> {
 
     async fn read<'a>(
         &self,
-        _buf: &'a mut [u8],
+        _buf: &'a mut Self::Buffer<'_>,
     ) -> Result<bt_hci::ControllerToHostPacket<'a>, Self::Error> {
         use bt_hci::event::{CommandComplete, CommandStatus, EventKind};
         use bt_hci::{ControllerToHostPacket, FromHciBytes};

--- a/src/host/uart.rs
+++ b/src/host/uart.rs
@@ -84,9 +84,7 @@ where
     T: Controller,
 {
     async fn read_packet(&self) -> Result<Packet, Error> {
-        const MAX_EVENT_LENGTH: usize = 256;
-
-        let mut packet = [0u8; MAX_EVENT_LENGTH];
+        let mut packet = self.alloc_buf().map_err(|_| Error::IoError)?;
         let pkt = <Self as Controller>::read(self, &mut packet)
             .await
             .map_err(|_| Error::IoError)?;

--- a/tests/vendor/mod.rs
+++ b/tests/vendor/mod.rs
@@ -41,6 +41,12 @@ impl embedded_io::ErrorType for RecordingSink {
 }
 
 impl bt_hci::controller::Controller for RecordingSink {
+    type Buffer<'a> = [u8; 259];
+
+    fn alloc_buf(&self) -> Result<Self::Buffer<'_>, Self::Error> {
+        Ok([0u8; 259])
+    }
+
     async fn write_acl_data(
         &self,
         _packet: &bt_hci::data::AclPacket<'_>,
@@ -64,7 +70,7 @@ impl bt_hci::controller::Controller for RecordingSink {
 
     async fn read<'a>(
         &self,
-        _buf: &'a mut [u8],
+        _buf: &'a mut Self::Buffer<'_>,
     ) -> Result<bt_hci::ControllerToHostPacket<'a>, Self::Error> {
         todo!()
     }
@@ -76,8 +82,8 @@ where
 {
     async fn exec(&self, cmd: &C) -> Result<C::Return, bt_hci::cmd::Error<Self::Error>> {
         use bt_hci::FromHciBytes;
-        use bt_hci::WriteHci;
         use bt_hci::transport::WithIndicator;
+        use bt_hci_transport::PacketToController;
 
         let mut data = self.data.lock().unwrap();
 
@@ -97,8 +103,8 @@ where
     C: bt_hci::cmd::AsyncCmd,
 {
     async fn exec(&self, cmd: &C) -> Result<(), bt_hci::cmd::Error<Self::Error>> {
-        use bt_hci::WriteHci;
         use bt_hci::transport::WithIndicator;
+        use bt_hci_transport::PacketToController;
 
         let mut data = self.data.lock().unwrap();
 


### PR DESCRIPTION
Allocate the receive buffer with the new Controller::alloc_buf instead of a fixed local array.